### PR TITLE
PNT1-50: Endpoint para listar Plazos Fijos por usuario

### DIFF
--- a/Wallet-grupo1/Controllers/FixedController.cs
+++ b/Wallet-grupo1/Controllers/FixedController.cs
@@ -78,5 +78,19 @@ public class FixedController : Controller
 
         return Ok();
     }
+    
+    [HttpGet("{userId}")]
+    public async Task<List<FixedTermDeposit>> FixedTermsOfUser([FromBody]int userId)
+    {
+        using (var uof = new UnitOfWork(_context))
+        {
+            var resultado = await uof.FixedRepo.FixedTermsOfUser(userId);
+
+            await uof.Complete();
+
+            return resultado;
+        }
+        
+    }
 
 }

--- a/Wallet-grupo1/DataAccess/Repositories/FixedTermDepositRepository.cs
+++ b/Wallet-grupo1/DataAccess/Repositories/FixedTermDepositRepository.cs
@@ -1,3 +1,4 @@
+using Microsoft.EntityFrameworkCore;
 using Wallet_grupo1.Entidades;
 
 namespace Wallet_grupo1.DataAccess.Repositories;
@@ -6,5 +7,11 @@ namespace Wallet_grupo1.DataAccess.Repositories;
     {
         public FixedTermDepositRepository(ApplicationDbContext context) : base(context)
         {
+            
+        }
+        public async Task<List<FixedTermDeposit>> FixedTermsOfUser(int userId)
+        {
+            return await _context.Transactions.Where(x => x.Account.User.Id == userId).
+                OrderByDescending(x => x.Date).ToListAsync();
         }
     }


### PR DESCRIPTION
Se agrega la lógica similar a la utilizada para las transacciones por cuenta/usuario, aprovechando las variables del header/cuerpo del request segun corresponda.