### PR TITLE
Hotfix: Encriptacion de contraseñas

### DIFF
--- a/Wallet-grupo1/DataAccess/DatabaseSeeding/UserSeeder.cs
+++ b/Wallet-grupo1/DataAccess/DatabaseSeeding/UserSeeder.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Wallet_grupo1.Entities;
+using Wallet_grupo1.Helpers;
 
 namespace Wallet_grupo1.DataAccess.DatabaseSeeding;
 
@@ -13,7 +14,7 @@ public class UserSeeder : IEntitySeeder
                 FirstName = "Cotton" ,
                 LastName = "Mather", 
                 Email = "cm@gmail.com",
-                Password = "cm2k23",
+                Password = PasswordEncryptHelper.EncryptPassword("cm2k23"),
                 Points = 1241,
                 RoleId = 1
             },
@@ -22,7 +23,7 @@ public class UserSeeder : IEntitySeeder
                 FirstName = "Deodat" ,
                 LastName = "Lawson", 
                 Email = "dl@gmail.com",
-                Password = "dl2k23",
+                Password = PasswordEncryptHelper.EncryptPassword("dl2k23"),
                 Points = 1242323,
                 RoleId = 1
             },
@@ -31,7 +32,7 @@ public class UserSeeder : IEntitySeeder
                 FirstName = "Giles" ,
                 LastName = "Corey", 
                 Email = "gc@gmail.com",
-                Password = "ed2k23",
+                Password = PasswordEncryptHelper.EncryptPassword("ed2k23"),
                 Points = 50,
                 RoleId = 1
             },
@@ -40,7 +41,7 @@ public class UserSeeder : IEntitySeeder
                 FirstName = "James" ,
                 LastName = "Bayley", 
                 Email = "jb@gmail.com",
-                Password = "jb2k23",
+                Password = PasswordEncryptHelper.EncryptPassword("jb2k23"),
                 Points = 50,
                 RoleId = 2
             },
@@ -49,7 +50,7 @@ public class UserSeeder : IEntitySeeder
                 FirstName = "John" ,
                 LastName = "Proctor", 
                 Email = "jp@gmail.com",
-                Password = "jp2k23",
+                Password = PasswordEncryptHelper.EncryptPassword("jp2k23"),
                 Points = 0,
                 RoleId = 2
             },
@@ -58,7 +59,7 @@ public class UserSeeder : IEntitySeeder
                 FirstName = "Mary" ,
                 LastName = "Eastey", 
                 Email = "me@gmail.com",
-                Password = "me2k23",
+                Password = PasswordEncryptHelper.EncryptPassword("me2k23"),
                 Points = 50231,
                 RoleId = 2
             }

--- a/Wallet-grupo1/Helpers/PasswordEncryptHelper.cs
+++ b/Wallet-grupo1/Helpers/PasswordEncryptHelper.cs
@@ -14,7 +14,7 @@ namespace Wallet_grupo1.Helpers
             stream = sha256.ComputeHash(encoding.GetBytes(str));
             for (int i = 0; i < stream.Length; i++)
             {
-                sb.AppendFormat("{0:2}", stream[i]);
+                sb.AppendFormat("{0:x2}", stream[i]);
             }
             return sb.ToString();
         }


### PR DESCRIPTION
Habia un error en el metodo encargado de encriptar las contraseñas produciendo siempre el mismo hash (que ademas era invalido). Se modifico y ahora se encriptan correctamente utilizando SHA256. Tambien se agrego la encriptacion en el seeder para que los users iniciales tambien se almacenen con password encriptada y de ese modo se pueda validar las credenciales correctamente.