### PR TITLE
PNT1-99: Agregar Documentación a Roles

### DIFF
--- a/Wallet-grupo1/Controllers/RoleController.cs
+++ b/Wallet-grupo1/Controllers/RoleController.cs
@@ -17,6 +17,10 @@ public class RoleController : Controller
         _unitOfWorkService = unitOfWorkService;
     }
     
+    /// <summary>
+    /// Obtener el listado de todos los roles del sistema. Solo usuarios administradores pueden acceder.
+    /// </summary>
+    /// <returns>Listado de todos los roles del sistema.</returns>
     [Authorize(Policy = "Admin")]
     [HttpGet]
     public async Task<IActionResult> GetAll()
@@ -26,6 +30,11 @@ public class RoleController : Controller
         return Ok(rolesPresent);
     }
     
+    /// <summary>
+    /// Obtener un rol a partir del ID especificado. Solo los administradores tienen acceso.
+    /// </summary>
+    /// <param name="id">ID del rol que se quiere recuperar.</param>
+    /// <returns>El estado del rol con el ID especificado.</returns>
     [Authorize(Policy = "Admin")]
     [HttpGet("{id}")]
     public async Task<IActionResult> GetById([FromRoute] int id)
@@ -37,6 +46,11 @@ public class RoleController : Controller
         return Ok(roleToFind);
     }
     
+    /// <summary>
+    /// Insertar un rol en la base de datos con los datos pasados en el Body.
+    /// </summary>
+    /// <param name="newRole">Estado en el que se quiere insertar el rol. El ID se autogenerará en la BD.</param>
+    /// <returns>El resultado de la creación e inserción de la entidad y su estado.</returns>
     [HttpPost]
     public async Task<IActionResult> Insert([FromBody] Role newRole)
     {
@@ -49,6 +63,11 @@ public class RoleController : Controller
         return CreatedAtAction("GetById", new { newRole.Id }, newRole);
     }
 
+    /// <summary>
+    /// Eliminar el rol de la base de datos cuyo ID corresponda con el especificado.
+    /// </summary>
+    /// <param name="id">ID del rol que se desea eliminar.</param>
+    /// <returns>Resultado de la transacción de eliminación</returns>
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete([FromRoute] int id)
     {
@@ -67,6 +86,11 @@ public class RoleController : Controller
         return Ok();
     }
     
+    /// <summary>
+    /// Actualizar el estado de un rol con los datos pasados en el body.
+    /// </summary>
+    /// <param name="roleToUpdate">Información del rol a actualizar.</param>
+    /// <returns>Resultado de la transacción de actualización.</returns>
     [HttpPut]
     public async Task<IActionResult> Update([FromBody] Role roleToUpdate)
     {

--- a/Wallet-grupo1/Program.cs
+++ b/Wallet-grupo1/Program.cs
@@ -1,9 +1,11 @@
+using System.Reflection;
 using System.Security.Claims;
 using System.Text;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Wallet_grupo1.Controllers;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi.Models;
 using Wallet_grupo1;
 using Wallet_grupo1.DataAccess;
 using Wallet_grupo1.Services;
@@ -15,7 +17,15 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllers();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
-builder.Services.AddSwaggerGen();
+builder.Services.AddSwaggerGen(c =>
+{
+    c.SwaggerDoc("v1", new OpenApiInfo { Title = "Wallet Grupo 1", Version = "v1" });
+
+    // Añadir comentarios XML a Swagger
+    var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
+    var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
+    c.IncludeXmlComments(xmlPath);
+});
 
 builder.Services.AddScoped<IUnitOfWork, UnitOfWorkService>();
 
@@ -48,7 +58,7 @@ var app = builder.Build();
 if (app.Environment.IsDevelopment())
 {
     app.UseSwagger();
-    app.UseSwaggerUI();
+    app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Wallet Grupo 1"));
 }
 
 app.UseHttpsRedirection();

--- a/Wallet-grupo1/Wallet-grupo1.csproj
+++ b/Wallet-grupo1/Wallet-grupo1.csproj
@@ -7,6 +7,14 @@
     <RootNamespace>Wallet_grupo1</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DocumentationFile>bin\Debug\Wallet-grupo1.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DocumentationFile>bin\Release\Wallet-grupo1.xml</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.9" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.4" />
@@ -35,6 +43,10 @@
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="Migrations" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Se agregó la documentación en cada uno de los endpoints del controlador de Roles. Además de eso se configuro el proyecto y Swagger para que muestre los comentarios, de esta forma se puede visualizar en la UI de Swagger dicha documentación.

Cuando se terminen bien los enpoints del CRUD vuelvo a revisar la documentacion y a completarla con algunas cosas más.

Así se ve la UI de Swagger ahora con los comentarios:
![imagen](https://user-images.githubusercontent.com/74569777/229376576-ab8b9586-f96e-4ada-9f98-96826661d105.png)
