### PR TITLE
PNT1-79: Endpoint Eliminación de un Account

### DIFF
--- a/Wallet-grupo1/Controllers/TransactionController.cs
+++ b/Wallet-grupo1/Controllers/TransactionController.cs
@@ -70,11 +70,13 @@ namespace Wallet_grupo1.Controllers
             
             var transaction = await _unitOfWorkService.TransactionRepo.GetById(id);
             if (transaction is null) return NotFound();
-            var account = await _unitOfWorkService.AccountRepo.GetById(transaction.AccountId);
+            
+            if(transaction.AccountId is null) return Forbid("El usuario loggeado no corresponde al del dueño de la cuenta.");
+            var account = await _unitOfWorkService.AccountRepo.GetById(transaction.AccountId.Value);
             if (account is null) return NotFound();
             
             if (account.UserId != int.Parse(userIdToken))
-                return Forbid("El usuario loggeado no corresponde al del dueño de la cuenta.");
+                return Forbid("El usuario loggeado no corresponde al del dueño de la cuenta .");
 
             return Ok(transaction);
         }

--- a/Wallet-grupo1/Controllers/UserController.cs
+++ b/Wallet-grupo1/Controllers/UserController.cs
@@ -51,7 +51,7 @@ namespace Wallet_grupo1.Controllers
             if (account is null) return NotFound($"No se encontro ningun account del user con el id: {id}.");
 
             // Elimino las Transaccion con Id la Account
-            var deletedTransaccions = await _unitOfWorkService.TransactionRepo.DeleteTransactionByAccount(account.Value.Id);
+            var deletedTransaccions = await _unitOfWorkService.TransactionRepo.RemoveReferencesToAccountId(account.Value.Id);
             if (!deletedTransaccions)
                 return StatusCode(500, $"No se pudo eliminar la Transaccion del user con id: {id}" +
                                        $" porque no existe o porque no se pudo completar la transacción.");

--- a/Wallet-grupo1/DataAccess/Repositories/TransactionRepository.cs
+++ b/Wallet-grupo1/DataAccess/Repositories/TransactionRepository.cs
@@ -65,17 +65,29 @@ namespace Wallet_grupo1.DataAccess.Repositories{
 
         }
 
-        public async Task<bool> DeleteTransactionByAccount(int accounId)
+        public async Task<bool> RemoveReferencesToAccountId(int accounId)
         {
             try
             {
-                // Elimino las Transaction con el Id de la Account
-                var transactions = await _context.Transactions.Where(x => x.AccountId == accounId).ToListAsync();
+                var transactionsFromAccoundId = 
+                    await _context.Transactions.Where(x => x.AccountId == accounId).ToListAsync();
+                var transactionsToAccountId =
+                    await _context.Transactions.Where(x => x.ToAccountId == accounId).ToListAsync();
 
-                if (transactions != null)
+                foreach (var t in transactionsFromAccoundId)
                 {
-                    _context.Transactions.RemoveRange(transactions);
+                    t.AccountId = null;
                 }
+
+                foreach (var t in transactionsToAccountId)
+                {
+                    t.ToAccountId = null;
+                }
+
+                var allTransactionsToUpdate = transactionsFromAccoundId.Concat(transactionsToAccountId);
+                
+                _context.Transactions.UpdateRange(allTransactionsToUpdate);
+                
                 return true;
             }
             catch

--- a/Wallet-grupo1/Entities/Transaction.cs
+++ b/Wallet-grupo1/Entities/Transaction.cs
@@ -25,8 +25,8 @@ namespace Wallet_grupo1.Entities
         public DateTime Date { get; set; }
         
         [Column("account_id")]
-        public int AccountId { get; set; }
-        public Account Account { get; set; }
+        public int? AccountId { get; set; }
+        public Account? Account { get; set; }
         
         [Column("to_account_id")]
         public int? ToAccountId { get; set; }

--- a/Wallet-grupo1/Entities/User.cs
+++ b/Wallet-grupo1/Entities/User.cs
@@ -40,7 +40,7 @@ public class User
         LastName = dto.LastName;
         Password = PasswordEncryptHelper.EncryptPassword(dto.Password);
         Email = dto.Email;
-        RoleId = 1;
+        RoleId = 2;
         Points = 0;
     }
 


### PR DESCRIPTION
Se agrego la logica para eliminar un account, para eso es necesario evitar errores por regla de integridad referencia lde la base de datos, por lo cual se eliminan tambien los plazos fijos de la account y las referencias a esa account en las transascciones. Se modifico el metodo que eliminaba las transacciones de account para dar lugar a un metodo que elimina simplmenete el puntero, de esta forma se peuede mantener el log de la transaccion (que al final sirve de historial de transacciones) por si se requiere mostrar por ejemplo las transacciones recibidas de una account que ya no existe (no se muestra account origen pues es null pero si el monto, fecha y los otros datos). Esa modificacion me llevo a tener que modificar otras clases.

Tambien se modificaron las respuestas utilizando el ResponseFactory para darle el formato requerido en el manejo de errores.

Resultado en Postman:
![imagen](https://user-images.githubusercontent.com/74569777/229379264-b00a48c5-fed9-4bff-9a13-10f45a50bc3e.png)
