### PR TITLE
PNT1-85: Endpoint Creación de FixedTermDeposits

### DIFF
--- a/Wallet-grupo1/Controllers/FixedController.cs
+++ b/Wallet-grupo1/Controllers/FixedController.cs
@@ -9,16 +9,27 @@ using Wallet_grupo1.Services;
 
 namespace Wallet_grupo1.Controllers;
 
+/// <summary>
+/// Controlador que provee la funcionalidades asociadas a los plazos fijos/inversiones con la wallet.
+/// </summary>
 [Route("api/deposit")]
 public class FixedController : Controller
 {
     private readonly IUnitOfWork _unitOfWorkService;
 
+    /// <summary>
+    /// Constructor base con su unidad de trabajo asociada las operaciones CRUD.
+    /// </summary>
     public FixedController(IUnitOfWork unitOfWork)
     {
         _unitOfWorkService = unitOfWork;
     }
-    //Obtenemos todos los Fixed
+    
+    /// <summary>
+    /// Endpoint que lista todos los plazos fijos en el sistema.
+    /// Requiere permisos de administrador.
+    /// </summary>
+    [Authorize(Policy = "Admin")]
     [HttpGet]
     public async Task<IActionResult> GetAll()
     {
@@ -40,7 +51,12 @@ public class FixedController : Controller
         return Ok(paginatedFixed);
     }
 
-    // Obtiene un Fixed mediante el ID
+    /// <summary>
+    /// Endpoint que lista los detalles de un plazo fijo segun su código identificador.
+    /// <param name="id">ID del plazo fijo que se desea consultar.</param>
+    /// <returns>Código de respuesta HTTP asociado al éxito o fracaso de la operación</returns>
+    /// </summary>
+    [Authorize(Policy = "Admin")]
     [HttpGet("{id}")]
     public async Task<IActionResult> GetById([FromRoute] int id)
     {
@@ -51,8 +67,13 @@ public class FixedController : Controller
         // Si se encuentra el Fixed, retorna un código 200 
         return Ok(Fixed);
     }
-  
-
+    
+    /// <summary>
+    /// Endpoint que inserta los detalles de un plazo fijo a partir del input de un usuario registrado.
+    /// <param name="Fixed">El constructor del plazo fijo</param>
+    /// <returns>Código de respuesta HTTP asociado al éxito o fracaso de la operación</returns>
+    /// </summary>
+    [Authorize]
     [HttpPost]
     public IActionResult Insert([FromBody] FixedTermDeposit Fixed)
     {
@@ -61,30 +82,37 @@ public class FixedController : Controller
 
         return CreatedAtAction(nameof(GetById), new { id = Fixed.Id }, Fixed);
     }
-    // Elimina un Fixed existente
+    
+    /// <summary>
+    /// Endpoint que elimina la fila de un plazo fijo a partir del código identificador.
+    /// <param name="id">El identificador del plazo fijo</param>
+    /// <returns>Código de respuesta HTTP asociado al éxito o fracaso de la operación</returns>
+    /// </summary>
     [Authorize(Policy = "Admin")]
     [HttpDelete("{id}")]
     public async Task<IActionResult> DeleteFixedTermDeposit([FromRoute] int id)
     {
-        // Obtiene el Id del fidex especificado utilizando el repositorio de Fixed.
+        // Obtiene el Id del FixedTerm especificado utilizando el repositorio de FixedTerms.
         var fixedTermDeposit = await _unitOfWorkService.FixedRepo.GetById(id);
 
         if (fixedTermDeposit is null) return ResponseFactory.CreateErrorResponse(404, $"No se encontró ningún plazo fijo con el id: {id}.");
 
         var result = await _unitOfWorkService.FixedRepo.Delete(fixedTermDeposit);
-
         if (!result)
             return ResponseFactory.CreateErrorResponse(500, $"No se pudo eliminar el plazo fijo con id: {id}" +
                                    $" porque no existe o porque no se pudo completar la transacción.");
 
         await _unitOfWorkService.Complete();
-
-
+        
         return ResponseFactory.CreateSuccessfullyResponse(200, "El plazo fijo se eliminó con éxito.");
     }
 
 
-    ///Actualiza un Fixed existente
+    /// <summary>
+    /// Endpoint que actualiza un plazo fijo segun su código identificador. Requiere permisos de administrador
+    /// <param name="Fixed">El constructor del plazo fijo</param>
+    /// <returns>Código de respuesta HTTP asociado al éxito o fracaso de la operación</returns>
+    /// </summary>
     [Authorize(Policy = "Admin")]
     [HttpPut("{id}")]
     public async Task<IActionResult> Update([FromRoute] int id, [FromBody] FixedTermDepositDto dto)
@@ -96,9 +124,14 @@ public class FixedController : Controller
         await _unitOfWorkService.Complete();
 
         return ResponseFactory.CreateSuccessfullyResponse(200, $"El plazo fijo con ID: {id} se actualizó con éxito.");
-
     }
 
+    
+    /// <summary>
+    /// Endpoint que lista los plazos segun el código identificador del usuario consumidor.
+    /// <param name="userId"></param>
+    /// <returns>Código de respuesta HTTP asociado al éxito o fracaso de la operación</returns>
+    /// </summary>
     [HttpGet("{userId}")]
     public async Task<List<FixedTermDeposit>> FixedTermsOfUser([FromBody] int userId)
     {
@@ -106,7 +139,6 @@ public class FixedController : Controller
         await _unitOfWorkService.Complete();
 
         return resultado;
-
     }
 
 }

--- a/Wallet-grupo1/Controllers/FixedController.cs
+++ b/Wallet-grupo1/Controllers/FixedController.cs
@@ -1,10 +1,12 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
 using Wallet_grupo1.DataAccess;
 using Wallet_grupo1.DTOs;
 using Wallet_grupo1.Entities;
 using Wallet_grupo1.Helpers;
 using Wallet_grupo1.Infrastructure;
+using Wallet_grupo1.Logic;
 using Wallet_grupo1.Services;
 
 namespace Wallet_grupo1.Controllers;
@@ -12,7 +14,7 @@ namespace Wallet_grupo1.Controllers;
 /// <summary>
 /// Controlador que provee la funcionalidades asociadas a los plazos fijos/inversiones con la wallet.
 /// </summary>
-[Route("api/deposit")]
+[Route("api/fixedTerm")]
 public class FixedController : Controller
 {
     private readonly IUnitOfWork _unitOfWorkService;
@@ -45,7 +47,7 @@ public class FixedController : Controller
 
         if (Fixed == null)
         {
-            return StatusCode(204, "No se encontraron FixedTermDeposit");
+            return StatusCode(204, "No se encontraron FixedTermDeposits");
         }
         // Retorna un código 200 (OK)
         return Ok(paginatedFixed);
@@ -53,9 +55,9 @@ public class FixedController : Controller
 
     /// <summary>
     /// Endpoint que lista los detalles de un plazo fijo segun su código identificador.
+    /// </summary>
     /// <param name="id">ID del plazo fijo que se desea consultar.</param>
     /// <returns>Código de respuesta HTTP asociado al éxito o fracaso de la operación</returns>
-    /// </summary>
     [Authorize(Policy = "Admin")]
     [HttpGet("{id}")]
     public async Task<IActionResult> GetById([FromRoute] int id)
@@ -70,24 +72,51 @@ public class FixedController : Controller
     
     /// <summary>
     /// Endpoint que inserta los detalles de un plazo fijo a partir del input de un usuario registrado.
-    /// <param name="Fixed">El constructor del plazo fijo</param>
-    /// <returns>Código de respuesta HTTP asociado al éxito o fracaso de la operación</returns>
     /// </summary>
+    /// <param name="newFixedTermDto">El constructor del plazo fijo</param>
+    /// <returns>Código de respuesta HTTP asociado al éxito o fracaso de la operación</returns>
     [Authorize]
-    [HttpPost]
-    public IActionResult Insert([FromBody] FixedTermDeposit Fixed)
+    [HttpPost("deposit")]
+    public async Task<IActionResult> CreateFixedTerm([FromBody] FixedTermDepositRequestDto newFixedTermDto)
     {
-        _unitOfWorkService.FixedRepo.Insert(Fixed);
-        _unitOfWorkService.Complete();
+        //Usamos el DTO para construir la entidad con los datos necesarios
+        var theNewFixedTerm = new FixedTermDeposit(newFixedTermDto.NewFixedTermDeposit);
+        
+        //Get token del header y validacion
+        string? authorizationHeader = Request.Headers["Authorization"];
 
-        return CreatedAtAction(nameof(GetById), new { id = Fixed.Id }, Fixed);
+        if (authorizationHeader is null) return Unauthorized("No se proporcionó un token de seguridad.");
+
+        if (string.IsNullOrEmpty(authorizationHeader) || !authorizationHeader.StartsWith("Bearer "))
+            return Unauthorized("No se proporcionó un token de seguridad válido.");
+
+        string jwtToken = authorizationHeader.Substring(7);
+
+        // Extraigo el userid del token (es un claim)
+        var userIdToken = TokenJwtHelper.ObtenerUserIdDeToken(jwtToken);
+        if (userIdToken is null) throw new SecurityTokenException("El token no tiene el claim del user id.");
+
+        Account? account;
+
+        account = _unitOfWorkService.AccountRepo.GetById(theNewFixedTerm.AccountId).Result;
+
+        if (account is null) return NotFound($"No se encontró ninguna cuenta con el número: {theNewFixedTerm.AccountId}.");
+
+        // Valido que sea el mismo user el loggeado y el dueño de la cuenta.
+        if (account.UserId != int.Parse(userIdToken))
+            return Forbid("La cuenta no pertenece al usuario loggeado.");
+        
+        // Delego al gestor la logica de creacion del plazo fijo.
+        await new GestorOperaciones(_unitOfWorkService).CreateFixedTerm(account, theNewFixedTerm, newFixedTermDto.InterestRate);
+
+        return ResponseFactory.CreateSuccessfullyResponse(201, newFixedTermDto);
     }
     
     /// <summary>
     /// Endpoint que elimina la fila de un plazo fijo a partir del código identificador.
+    /// </summary>
     /// <param name="id">El identificador del plazo fijo</param>
     /// <returns>Código de respuesta HTTP asociado al éxito o fracaso de la operación</returns>
-    /// </summary>
     [Authorize(Policy = "Admin")]
     [HttpDelete("{id}")]
     public async Task<IActionResult> DeleteFixedTermDeposit([FromRoute] int id)
@@ -110,9 +139,9 @@ public class FixedController : Controller
 
     /// <summary>
     /// Endpoint que actualiza un plazo fijo segun su código identificador. Requiere permisos de administrador
+    /// </summary>
     /// <param name="Fixed">El constructor del plazo fijo</param>
     /// <returns>Código de respuesta HTTP asociado al éxito o fracaso de la operación</returns>
-    /// </summary>
     [Authorize(Policy = "Admin")]
     [HttpPut("{id}")]
     public async Task<IActionResult> Update([FromRoute] int id, [FromBody] FixedTermDepositDto dto)
@@ -129,9 +158,9 @@ public class FixedController : Controller
     
     /// <summary>
     /// Endpoint que lista los plazos segun el código identificador del usuario consumidor.
+    /// </summary>
     /// <param name="userId"></param>
     /// <returns>Código de respuesta HTTP asociado al éxito o fracaso de la operación</returns>
-    /// </summary>
     [HttpGet("{userId}")]
     public async Task<List<FixedTermDeposit>> FixedTermsOfUser([FromBody] int userId)
     {

--- a/Wallet-grupo1/DTOs/FixedTermDepositDto.cs
+++ b/Wallet-grupo1/DTOs/FixedTermDepositDto.cs
@@ -5,4 +5,6 @@ public class FixedTermDepositDto
     public DateTime ClosingDate { get; set; }
     
     public decimal Amount { get; set; }
+    
+    public int OwnerAccountId { get; set; }
 }

--- a/Wallet-grupo1/DTOs/FixedTermDepositDto.cs
+++ b/Wallet-grupo1/DTOs/FixedTermDepositDto.cs
@@ -3,8 +3,6 @@
 public class FixedTermDepositDto
 {
     public DateTime ClosingDate { get; set; }
-    
     public decimal Amount { get; set; }
-    
-    public int OwnerAccountId { get; set; }
+    public int AccountId { get; set; }
 }

--- a/Wallet-grupo1/DTOs/FixedTermDepositRequestDto.cs
+++ b/Wallet-grupo1/DTOs/FixedTermDepositRequestDto.cs
@@ -1,0 +1,7 @@
+﻿namespace Wallet_grupo1.DTOs;
+
+public class FixedTermDepositRequestDto
+{
+    public FixedTermDepositDto NewFixedTermDeposit { get; set; }
+    public int InterestRate { get; set; }
+}

--- a/Wallet-grupo1/DataAccess/Repositories/CatalogueRepository.cs
+++ b/Wallet-grupo1/DataAccess/Repositories/CatalogueRepository.cs
@@ -17,29 +17,37 @@ namespace Wallet_grupo1.DataAccess.Repositories{
     public CatalogueRepository(ApplicationDbContext context) : base(context)
     {
     }
-    
-        /// <summary>
-        /// Operación CRUD para remover un catálogo del arreglo interno de la aplicación y el contexto de la DB
-        /// </summary>
-        /// <param name="catalogueToDelete"></param>
-        /// <returns>Booleano representativo del éxito o fracaso de la operación</returns>
-        public override async Task<bool> Delete(Catalogue catalogueToDelete)
+
+    /// <summary>
+    /// Operación CRUD para remover un catálogo del arreglo interno de la aplicación y el contexto de la DB
+    /// </summary>
+    /// <param name="catalogueToDelete"></param>
+    /// <returns>Booleano representativo del éxito o fracaso de la operación</returns>
+    public override async Task<bool> Delete(Catalogue catalogueToDelete)
+    {
+        try
         {
-            try
+            var catalogue = await _context.Catalogues.Where(x => x.Id == catalogueToDelete.Id).FirstOrDefaultAsync();
+
+            if (catalogue != null)
             {
-                var catalogue = await _context.Catalogues.Where(x => x.Id == catalogueToDelete.Id).FirstOrDefaultAsync();
-
-                if (catalogue != null)
-                {
-                    _context.Catalogues.Remove(catalogue);
-                }
+                _context.Catalogues.Remove(catalogue);
             }
-            catch (Exception)
-            {
-                return false;
-            }
+        }
+        catch (Exception)
+        {
+            return false;
+        }
+
+        return true;
+    }
 
 
+    /// <summary>
+    /// Operación CRUD para remover un catálogo del arreglo interno de la aplicación y el contexto de la DB
+    /// </summary>
+    /// <param name="catalogueToUpdate"></param>
+    /// <returns>Booleano representativo del éxito o fracaso de la operación</returns>
     public override async Task<bool> Update(Catalogue entity)
         {
             try

--- a/Wallet-grupo1/DataAccess/Repositories/FixedTermDepositRepository.cs
+++ b/Wallet-grupo1/DataAccess/Repositories/FixedTermDepositRepository.cs
@@ -4,14 +4,20 @@ using Wallet_grupo1.Entities;
 
 namespace Wallet_grupo1.DataAccess.Repositories
 {
-
+    /// <summary>
+    /// Repositorio concreto asociado a los plazos fijos
+    /// </summary>
     public class FixedTermDepositRepository : Repository<FixedTermDeposit>, IFixedTermDepositRepository
     {
+        
         public FixedTermDepositRepository(ApplicationDbContext context) : base(context)
         {
-
         }
-
+        
+        
+        /// <summary>
+        /// Actualizacion de campos del plazo fijo en funcion de request HTTP
+        /// </summary>
         public override async Task<bool> Update(FixedTermDeposit updatedDeposit)
         {
             try
@@ -34,6 +40,9 @@ namespace Wallet_grupo1.DataAccess.Repositories
             return true;
         }
 
+        /// <summary>
+        /// Busqueda y listado de plazo fijos para usuario en funcion de request HTTP
+        /// </summary>
         public async Task<List<FixedTermDeposit>> FixedTermsOfUser(int userId)
         {
             return await _context.FixedTermDeposits
@@ -42,6 +51,9 @@ namespace Wallet_grupo1.DataAccess.Repositories
                 .ToListAsync();
         }
 
+        /// <summary>
+        /// Busqueda y listado de plazo fijos para usuario en funcion de request HTTP
+        /// </summary>
         public async Task<bool> DeleteFixedTermsByAccount(int accounId)
         {
             try
@@ -61,34 +73,13 @@ namespace Wallet_grupo1.DataAccess.Repositories
             }
         }
 
-
-
-        //usa este delete de referencia para crear el de este repositorio
-        //         public override async Task<bool> Delete(Account entity)
-        // {
-        //     try
-        //     {
-        //         var account = await _context.Accounts.FindAsync(entity.Id);
-
-        //         // Si no se encontró ninguna entidad con ese ID no tiene sentido seguir.
-        //         if (account is null) return false;
-
-        //         _context.Accounts.Remove(account);
-        //     }
-        //     catch (Exception)
-        //     {
-        //         return false;
-        //     }
-
-        //     return true;
-        // }
-
+        /// <summary>
+        /// Eliminación de plazo fijo por admin en funcion de request HTTP
+        /// </summary>
         public override async Task<bool> Delete(FixedTermDeposit fixedTermDeposit)
         {
             try
             {
-
-
                 // Si no se encontró ninguna entidad con ese ID no tiene sentido seguir.
                 if (fixedTermDeposit is null) return false;
 

--- a/Wallet-grupo1/Entities/FixedTermDeposit.cs
+++ b/Wallet-grupo1/Entities/FixedTermDeposit.cs
@@ -44,9 +44,10 @@ namespace Wallet_grupo1.Entities
         /// </summary>
         public FixedTermDeposit(FixedTermDepositDto dto)
         {
+            CreationDate = DateTime.Now;
             ClosingDate = dto.ClosingDate;
             Amount = dto.Amount;
-            AccountId = dto.OwnerAccountId;
+            AccountId = dto.AccountId;
         }
         
         /// <summary>

--- a/Wallet-grupo1/Entities/FixedTermDeposit.cs
+++ b/Wallet-grupo1/Entities/FixedTermDeposit.cs
@@ -4,6 +4,10 @@ using Wallet_grupo1.DTOs;
 
 namespace Wallet_grupo1.Entities
 {
+    /// <summary>
+    /// Entidad Plazo fijo, compuesta por un campo identificador, una cantidad de dinero invertida, una fecha
+    /// de inicio y otra de finalización para cobrar los intereses y el id de la cuenta asociada al mismo.
+    /// </summary>
     public class FixedTermDeposit
     {
         [Column("fixedterm_id")]
@@ -25,6 +29,9 @@ namespace Wallet_grupo1.Entities
         public int AccountId { get; set; }
         public Account Account { get; set; } = null!;
 
+        /// <summary>
+        /// Data transfer objects asociados al plazo fijo.
+        /// </summary>
         public FixedTermDeposit(int id, FixedTermDepositDto dto)
         {
             Id = id;
@@ -32,6 +39,19 @@ namespace Wallet_grupo1.Entities
             Amount = dto.Amount;
         }
         
+        /// <summary>
+        /// Data transfer objects asociados al plazo fijo.
+        /// </summary>
+        public FixedTermDeposit(FixedTermDepositDto dto)
+        {
+            ClosingDate = dto.ClosingDate;
+            Amount = dto.Amount;
+            AccountId = dto.OwnerAccountId;
+        }
+        
+        /// <summary>
+        /// Data transfer objects asociados al plazo fijo.
+        /// </summary>
         public FixedTermDeposit(){}
     }
 }

--- a/Wallet-grupo1/Logic/GestorOperaciones.cs
+++ b/Wallet-grupo1/Logic/GestorOperaciones.cs
@@ -56,4 +56,14 @@ public class GestorOperaciones
 
         await _unitOfWorkService.TransactionRepo.Insert(transaction);
     }
+
+    public async Task CreateFixedTerm(Account userAccount, FixedTermDeposit theNewFixedTerm, int interestWage)
+    {
+        userAccount.Money -= theNewFixedTerm.Amount; 
+        theNewFixedTerm.Amount += ((theNewFixedTerm.Amount) * interestWage) / 100;
+        
+        await _unitOfWorkService.AccountRepo.Update(userAccount);
+        await _unitOfWorkService.FixedRepo.Insert(theNewFixedTerm);
+        await _unitOfWorkService.Complete();
+    }
 }


### PR DESCRIPTION
Implemento la lógica para la creación de un Plazo fijo nuevo, ajustando el body del request a un DTO con los campos necesarios,  sumando un dato que represente la tasa de interés nominal efectiva para la inversión. Pendiente de mejoras en algunas validaciones de manejo de errores.

A modo de ejemplo, crearemos un plazo fijo nuevo adicional a los 4 presentes en la base con los fondos de la cuenta número 6:

![Ssms_lB3aiQNEou](https://user-images.githubusercontent.com/26391685/230894020-c6c641a5-5c42-4f40-aebd-34a7d1393238.jpg)
![Ssms_iaod3aqTLi](https://user-images.githubusercontent.com/26391685/230893853-e8747ba7-78b8-40da-8a74-0c0a636c7ff3.jpg)

Efectuamos el pedido via Postman:
![Postman_Fg0Uk3W0vx](https://user-images.githubusercontent.com/26391685/230893889-00b68212-7bd5-4009-aa78-85a169e13712.jpg)

Validamos que el monto en el plazo fijo nuevo insertado posee el valor de dinero final (inversión + interés generado):
![Ssms_8gCPAabWHJ](https://user-images.githubusercontent.com/26391685/230894698-807f863c-0222-4950-a034-b89bfb71c20c.jpg)


El estado de la cuenta se actualiza:
![Ssms_EUMk8RUNIW](https://user-images.githubusercontent.com/26391685/230894424-0b2b8d9f-705d-491e-9af3-ed73ca568de0.jpg)









